### PR TITLE
fix: wrong data offset when handling LVAL type2

### DIFF
--- a/src/MdbReader/Values/MdbLvalStream.cs
+++ b/src/MdbReader/Values/MdbLvalStream.cs
@@ -109,7 +109,7 @@ public class MdbLValStream : Stream
             }
 
             int lengthLeft = _lengthInBuffer - (_position - _bufferStartPos);
-            if (lengthLeft < 0)
+            if (lengthLeft <= 0)
             {
                 // Grab the next page
                 _bufferStartPos = _position;
@@ -117,9 +117,9 @@ public class MdbLValStream : Stream
                 lengthLeft = _lengthInBuffer - (_position - _bufferStartPos);
             }
             int numToSend = Math.Min(buffer.Length - numSent, lengthLeft);
-            Buffer.AsSpan(_position - _bufferStartPos, numToSend).CopyTo(buffer);
+            Buffer.AsSpan(_position - _bufferStartPos, numToSend).CopyTo(buffer.Slice(numSent));
             numSent += numToSend;
-            _position += numSent;
+            _position += numToSend;
         }
 
         return numSent;


### PR DESCRIPTION
This PR can pass all tests of `WindowsTests`, but fail on some tests of `MdbReaderTests` which I think has some incorrect assertions?
