### PR TITLE
Avoid object unnecessary allocations

### DIFF
--- a/src/MdbReader/MdbColumn.cs
+++ b/src/MdbReader/MdbColumn.cs
@@ -41,7 +41,7 @@ public sealed record class MdbColumn
     /// See <seealso href="https://learn.microsoft.com/en-us/sql/odbc/microsoft/microsoft-access-data-types?view=sql-server-ver16" />
     /// for a list of all SQL data types and their equivalent names in the Access GUI.
     /// </remarks>
-    public string SqlTypeName => (Type, Flags.HasFlag(MdbColumnFlags.FixedLength)) switch
+    public string SqlTypeName => (Type, Flags.HasFlagFast(MdbColumnFlags.FixedLength)) switch
     {
         (MdbColumnType.Boolean, _) => "BIT",
         (MdbColumnType.Byte, _) => "UNSIGNED BYTE",

--- a/src/MdbReader/MdbDataRow.Helpers.cs
+++ b/src/MdbReader/MdbDataRow.Helpers.cs
@@ -7,7 +7,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-using MMKiwi.Collections;
 using MMKiwi.MdbReader.Values;
 
 namespace MMKiwi.MdbReader;
@@ -16,18 +15,17 @@ public sealed partial class MdbDataRow
 {
     private IMdbValue GetFieldValue(int index)
     {
-        if (index < 0 || index >= Fields.Count)
+        if (index < 0 || index >= _fields.Length)
             throw new IndexOutOfRangeException($"Index {index} was out of range. Must be non-negative and less than the size of the collection.");
-        return Fields[index];
+        return _fields[index];
     }
 
     private IMdbValue GetFieldValue(string columnName)
     {
         if (columnName is null)
             throw new ArgumentNullException(nameof(columnName));
-        if (!Fields.Contains(columnName))
-            throw new IndexOutOfRangeException($"Column {columnName} does not exist.");
-        return Fields[columnName];
+
+        return _fields[GetColumnIndex(columnName)];
     }
 
     private static void ThrowIfNullCast(IMdbValue fieldValue, string typeName)
@@ -40,15 +38,5 @@ public sealed partial class MdbDataRow
     private static T ThrowInvalidCast<T>(IMdbValue fieldValue, string typeName)
     {
         throw new InvalidCastException($"Could not convert {fieldValue.Column.Type} value to {typeName}");
-    }
-
-    private class FieldCollection : ImmutableKeyedCollection<string, IMdbValue>
-    {
-        internal FieldCollection(ImmutableArray<IMdbValue> baseCollection, IEqualityComparer<string>? comparer, int dictionaryCreationThreshold) : base(baseCollection, comparer, dictionaryCreationThreshold)
-        {
-        }
-
-        /// <inheritdocs />
-        protected override string GetKeyForItem(IMdbValue item) => item.Column.Name;
     }
 }

--- a/src/MdbReader/MdbReaderOptions.cs
+++ b/src/MdbReader/MdbReaderOptions.cs
@@ -18,6 +18,11 @@ public record class MdbReaderOptions
     public IEqualityComparer<string> TableNameComparison { get; }
 
     /// <summary>
+    /// Gets the minimum number of columns required before a dictionary is created for column lookups.
+    /// </summary>
+    public int RowDictionaryCreationThreshold { get; set; } = 10;
+
+    /// <summary>
     /// Initializes a new instance of <see cref="MdbReaderOptions" />
     /// </summary>
     /// <param name="tableNameComparison">The string comparer to use for table names in the <see cref="MdbTables" /> collection.</param>

--- a/src/MdbReader/MdbRows.cs
+++ b/src/MdbReader/MdbRows.cs
@@ -31,7 +31,7 @@ public class MdbRows : IEnumerable<MdbDataRow>, IAsyncEnumerable<MdbDataRow>
         foreach (int page in Reader.GetUsageMap(usageMap))
         {
             await foreach (var row in Reader.ReadDataPageAsync(page, Table, new HashSet<string>(0), ct))
-                yield return new(row, Reader.Options.TableNameComparison, 10);
+                yield return new(row, Reader.Options.TableNameComparison, Reader.Options.RowDictionaryCreationThreshold);
         }
     }
 
@@ -43,7 +43,7 @@ public class MdbRows : IEnumerable<MdbDataRow>, IAsyncEnumerable<MdbDataRow>
         foreach (int page in Reader.GetUsageMap(usageMap))
         {
             foreach (var row in Reader.ReadDataPage(page, Table, new HashSet<string>(0)))
-                yield return new(row, Reader.Options.TableNameComparison, 10);
+                yield return new(row, Reader.Options.TableNameComparison, Reader.Options.RowDictionaryCreationThreshold);
         }
     }
 

--- a/src/MdbReader/MdbRows.cs
+++ b/src/MdbReader/MdbRows.cs
@@ -27,11 +27,12 @@ public class MdbRows : IEnumerable<MdbDataRow>, IAsyncEnumerable<MdbDataRow>
     public async IAsyncEnumerator<MdbDataRow> GetAsyncEnumerator(CancellationToken ct = default)
     {
         byte[] usageMap = Reader.ReadUsageMap(Table.UsedPagesPtr);
+        var columnMap = Reader.CreateColumnMap(Table.Columns, null, Reader.Options.TableNameComparison, Reader.Options.RowDictionaryCreationThreshold);
 
         foreach (int page in Reader.GetUsageMap(usageMap))
         {
-            await foreach (var row in Reader.ReadDataPageAsync(page, Table, new HashSet<string>(0), ct))
-                yield return new(row, Reader.Options.TableNameComparison, Reader.Options.RowDictionaryCreationThreshold);
+            await foreach (var row in Reader.ReadDataPageAsync(page, Table, null, ct))
+                yield return new(row, Reader.Options.TableNameComparison, columnMap);
         }
     }
 
@@ -39,11 +40,12 @@ public class MdbRows : IEnumerable<MdbDataRow>, IAsyncEnumerable<MdbDataRow>
     public IEnumerator<MdbDataRow> GetEnumerator()
     {
         byte[] usageMap = Reader.ReadUsageMap(Table.UsedPagesPtr);
+        var columnMap = Reader.CreateColumnMap(Table.Columns, null, Reader.Options.TableNameComparison, Reader.Options.RowDictionaryCreationThreshold);
 
         foreach (int page in Reader.GetUsageMap(usageMap))
         {
-            foreach (var row in Reader.ReadDataPage(page, Table, new HashSet<string>(0)))
-                yield return new(row, Reader.Options.TableNameComparison, Reader.Options.RowDictionaryCreationThreshold);
+            foreach (var row in Reader.ReadDataPage(page, Table, null))
+                yield return new(row, Reader.Options.TableNameComparison, columnMap);
         }
     }
 

--- a/src/MdbReader/Values/MdbBinaryValue.cs
+++ b/src/MdbReader/Values/MdbBinaryValue.cs
@@ -28,8 +28,11 @@ namespace MMKiwi.MdbReader.Values;
 [DebuggerDisplay("{Column.Name}: {Value}")]
 internal sealed class MdbBinaryValue : MdbValue<ImmutableArray<byte>>, IValueAllowableType
 {
-    internal MdbBinaryValue(MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
-        : base(column, isNull, binaryValue, 0, column.Length, AllowableType) { }
+    internal MdbBinaryValue(MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
+        : base(column, isNull, binaryValue, 0, column.Length, AllowableType)
+    {
+        Value = isNull ? ImmutableArray<byte>.Empty : binaryValue.ToImmutableArray();
+    }
 
     /// <summary>
     /// The <see cref="MdbColumnType" /> that can be used for this value.
@@ -45,5 +48,5 @@ internal sealed class MdbBinaryValue : MdbValue<ImmutableArray<byte>>, IValueAll
     /// Note that if <see cref="MdbColumnFlags.FixedLength" /> is set for <see cref="MdbColumn.Flags" />, 
     /// there may be null bytes appended to the end in order to reach the fixed length.
     /// </remarks>
-    public override ImmutableArray<byte> Value => BinaryValue;
+    public override ImmutableArray<byte> Value { get; }
 }

--- a/src/MdbReader/Values/MdbBoolValue.cs
+++ b/src/MdbReader/Values/MdbBoolValue.cs
@@ -23,7 +23,7 @@ namespace MMKiwi.MdbReader.Values;
 internal sealed class MdbBoolValue : MdbValue<bool>, IValueAllowableType
 {
     internal MdbBoolValue(MdbColumn column, bool isNull)
-     : base(column, false, ImmutableArray<byte>.Empty, 0, 0, AllowableType)
+     : base(column, false, default, 0, 0, AllowableType)
     {
         Value = !isNull;
     }

--- a/src/MdbReader/Values/MdbByteValue.cs
+++ b/src/MdbReader/Values/MdbByteValue.cs
@@ -26,8 +26,14 @@ namespace MMKiwi.MdbReader.Values;
 [DebuggerDisplay("{Column.Name}: {Value}")]
 internal sealed class MdbByteValue : MdbValue<byte>, IValueAllowableType
 {
-    internal MdbByteValue(MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
-        : base(column, isNull, binaryValue, 1, 1, AllowableType) { }
+    internal MdbByteValue(MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
+        : base(column, isNull, binaryValue, 1, 1, AllowableType)
+    {
+        if (!isNull)
+        {
+            Value = ConversionFunctions.AsByte(binaryValue);
+        }
+    }
 
     /// <summary>
     /// The <see cref="MdbColumnType" /> that can be used for this value.
@@ -38,6 +44,5 @@ internal sealed class MdbByteValue : MdbValue<byte>, IValueAllowableType
     /// <summary>
     /// The value for the specific row and column. A <see cref="byte" /> (values from 0 to 255).
     /// </summary>
-    public override byte Value => ConversionFunctions.AsByte(BinaryValue.AsSpan());
-
+    public override byte Value { get; }
 }

--- a/src/MdbReader/Values/MdbCurrencyValue.cs
+++ b/src/MdbReader/Values/MdbCurrencyValue.cs
@@ -24,8 +24,14 @@ namespace MMKiwi.MdbReader.Values;
 [DebuggerDisplay("{Column.Name}: {Value}")]
 internal sealed class MdbCurrencyValue : MdbValue<decimal>, IValueAllowableType
 {
-    internal MdbCurrencyValue(MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
-        : base(column, isNull, binaryValue, 8, 8, AllowableType) { }
+    internal MdbCurrencyValue(MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
+        : base(column, isNull, binaryValue, 8, 8, AllowableType)
+    {
+        if (!isNull)
+        {
+            Value = ConversionFunctions.AsCurrency(binaryValue);
+        }
+    }
 
     /// <summary>
     /// The <see cref="MdbColumnType" /> that can be used for this value.
@@ -36,5 +42,5 @@ internal sealed class MdbCurrencyValue : MdbValue<decimal>, IValueAllowableType
     /// <summary>
     /// The value for the specific row and column. A <see cref="decimal" />.
     /// </summary>
-    public override decimal Value => ConversionFunctions.AsCurrency(BinaryValue.AsSpan());
+    public override decimal Value { get; }
 }

--- a/src/MdbReader/Values/MdbDateTimeValue.cs
+++ b/src/MdbReader/Values/MdbDateTimeValue.cs
@@ -26,8 +26,14 @@ namespace MMKiwi.MdbReader.Values;
 [DebuggerDisplay("{Column.Name}: {Value}")]
 internal sealed class MdbDateTimeValue : MdbValue<DateTime>, IValueAllowableType
 {
-    internal MdbDateTimeValue(MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
-        : base(column, isNull, binaryValue, 8, 8, AllowableType) { }
+    internal MdbDateTimeValue(MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
+        : base(column, isNull, binaryValue, 8, 8, AllowableType)
+    {
+        if (!isNull)
+        {
+            Value = ConversionFunctions.AsDateTime(binaryValue);
+        }
+    }
 
     /// <summary>
     /// The <see cref="MdbColumnType" /> that can be used for this value.
@@ -38,6 +44,5 @@ internal sealed class MdbDateTimeValue : MdbValue<DateTime>, IValueAllowableType
     /// <summary>
     /// The value for the specific row and column. A <see cref="DateTime" />.
     /// </summary>
-    public override DateTime Value => ConversionFunctions.AsDateTime(BinaryValue.AsSpan());
-
+    public override DateTime Value { get; }
 }

--- a/src/MdbReader/Values/MdbDoubleValue.cs
+++ b/src/MdbReader/Values/MdbDoubleValue.cs
@@ -25,8 +25,14 @@ namespace MMKiwi.MdbReader.Values;
 [DebuggerDisplay("{Column.Name}: {Value}")]
 internal sealed class MdbDoubleValue : MdbValue<double>, IValueAllowableType
 {
-    internal MdbDoubleValue(MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
-        : base(column, isNull, binaryValue, 8, 8, AllowableType) { }
+    internal MdbDoubleValue(MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
+        : base(column, isNull, binaryValue, 8, 8, AllowableType)
+    {
+        if (!isNull)
+        {
+            Value = ConversionFunctions.AsDouble(binaryValue);
+        }
+    }
 
     /// <summary>
     /// The <see cref="MdbColumnType" /> that can be used for this value.
@@ -37,6 +43,5 @@ internal sealed class MdbDoubleValue : MdbValue<double>, IValueAllowableType
     /// <summary>
     /// The value for the specific row and column. A <see cref="double" />.
     /// </summary>
-    public override double Value => ConversionFunctions.AsDouble(BinaryValue.AsSpan());
-
+    public override double Value { get; }
 }

--- a/src/MdbReader/Values/MdbGuidValue.cs
+++ b/src/MdbReader/Values/MdbGuidValue.cs
@@ -25,8 +25,14 @@ namespace MMKiwi.MdbReader.Values;
 [DebuggerDisplay("{Column.Name}: {Value}")]
 internal sealed class MdbGuidValue : MdbValue<Guid>, IValueAllowableType
 {
-    internal MdbGuidValue(MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
-        : base(column, isNull, binaryValue, 16, 16, AllowableType) { }
+    internal MdbGuidValue(MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
+        : base(column, isNull, binaryValue, 16, 16, AllowableType)
+    {
+        if (!isNull)
+        {
+            Value = ConversionFunctions.AsGuid(binaryValue);
+        }
+    }
     /// <summary>
     /// The <see cref="MdbColumnType" /> that can be used for this value.
     /// This will always be <see cref="MdbColumnType.Guid" />
@@ -36,6 +42,6 @@ internal sealed class MdbGuidValue : MdbValue<Guid>, IValueAllowableType
     /// <summary>
     /// The value for the specific row and column. A <see cref="Guid" />
     /// </summary>
-    public override Guid Value => ConversionFunctions.AsGuid(BinaryValue.AsSpan());
+    public override Guid Value { get; }
 
 }

--- a/src/MdbReader/Values/MdbIntValue.cs
+++ b/src/MdbReader/Values/MdbIntValue.cs
@@ -26,8 +26,14 @@ namespace MMKiwi.MdbReader.Values;
 [DebuggerDisplay("{Column.Name}: {Value}")]
 internal sealed class MdbIntValue : MdbValue<short>, IValueAllowableType
 {
-    internal MdbIntValue(MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
-        : base(column, isNull, binaryValue, 2, 2, AllowableType) { }
+    internal MdbIntValue(MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
+        : base(column, isNull, binaryValue, 2, 2, AllowableType)
+    {
+        if (!isNull)
+        {
+            Value = ConversionFunctions.AsShort(binaryValue);
+        }
+    }
 
     /// <summary>
     /// The <see cref="MdbColumnType" /> that can be used for this value.
@@ -38,6 +44,6 @@ internal sealed class MdbIntValue : MdbValue<short>, IValueAllowableType
     /// <summary>
     /// The value for the specific row and column. A <see cref="short" /> (values from -32768 to 32767).
     /// </summary>
-    public override short Value => ConversionFunctions.AsShort(BinaryValue.AsSpan());
+    public override short Value { get; }
 
 }

--- a/src/MdbReader/Values/MdbLValValueBase.cs
+++ b/src/MdbReader/Values/MdbLValValueBase.cs
@@ -16,11 +16,18 @@ namespace MMKiwi.MdbReader.Values;
 /// </typeparam>
 internal abstract class MdbLongValField<TOut> : MdbValue<TOut>
 {
-    private protected MdbLongValField(Jet3Reader reader, MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue, MdbColumnType allowableType)
+    private protected MdbLongValField(Jet3Reader reader, MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue, MdbColumnType allowableType)
         : base(column, isNull, binaryValue, 0, int.MaxValue, allowableType)
     {
+        if (!isNull)
+        {
+            BinaryValue = binaryValue.ToArray();
+        }
+
         Reader = reader;
     }
 
     protected private Jet3Reader Reader { get; }
+
+    protected ReadOnlyMemory<byte> BinaryValue { get; }
 }

--- a/src/MdbReader/Values/MdbLongIntValue.cs
+++ b/src/MdbReader/Values/MdbLongIntValue.cs
@@ -26,8 +26,14 @@ namespace MMKiwi.MdbReader.Values;
 [DebuggerDisplay("{Column.Name}: {Value}")]
 internal sealed class MdbLongIntValue : MdbValue<int>, IValueAllowableType
 {
-    internal MdbLongIntValue(MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
-        : base(column, isNull, binaryValue, 4, 4, AllowableType) { }
+    internal MdbLongIntValue(MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
+        : base(column, isNull, binaryValue, 4, 4, AllowableType)
+    {
+        if (!isNull)
+        {
+            Value = ConversionFunctions.AsInt(binaryValue);
+        }
+    }
 
     /// <summary>
     /// The <see cref="MdbColumnType" /> that can be used for this value.
@@ -38,6 +44,6 @@ internal sealed class MdbLongIntValue : MdbValue<int>, IValueAllowableType
     /// <summary>
     /// The value for the specific row and column. An <see cref="int" />
     /// </summary>
-    public override int Value => ConversionFunctions.AsInt(BinaryValue.AsSpan());
+    public override int Value { get; }
 
 }

--- a/src/MdbReader/Values/MdbMemoValue.cs
+++ b/src/MdbReader/Values/MdbMemoValue.cs
@@ -28,7 +28,7 @@ namespace MMKiwi.MdbReader.Values;
 internal class MdbMemoValue : MdbLongValField<MdbLValStream?>, IValueAllowableType
 {
 
-    internal MdbMemoValue(Jet3Reader reader, MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
+    internal MdbMemoValue(Jet3Reader reader, MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
         : base(reader, column, isNull, binaryValue, AllowableType)
     {
         Encoding = (column.ColumnInfo as MdbTextColumnInfo)!.Encoding;

--- a/src/MdbReader/Values/MdbOleValue.cs
+++ b/src/MdbReader/Values/MdbOleValue.cs
@@ -20,7 +20,7 @@ namespace MMKiwi.MdbReader.Values;
 [DebuggerDisplay("{Column.Name}: [OLE]")]
 internal class MdbOleValue : MdbLongValField<MdbLValStream?>, IValueAllowableType
 {
-    internal MdbOleValue(Jet3Reader reader, MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
+    internal MdbOleValue(Jet3Reader reader, MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
         : base(reader, column, isNull, binaryValue, AllowableType)
     {
     }

--- a/src/MdbReader/Values/MdbSingleValue.cs
+++ b/src/MdbReader/Values/MdbSingleValue.cs
@@ -24,8 +24,14 @@ namespace MMKiwi.MdbReader.Values;
 [DebuggerDisplay("{Column.Name}: {Value}")]
 internal sealed class MdbSingleValue : MdbValue<float>, IValueAllowableType
 {
-    internal MdbSingleValue(MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
-        : base(column, isNull, binaryValue, 4, 4, AllowableType) { }
+    internal MdbSingleValue(MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
+        : base(column, isNull, binaryValue, 4, 4, AllowableType)
+    {
+        if (!isNull)
+        {
+            Value = ConversionFunctions.AsSingle(binaryValue);
+        }
+    }
 
     /// <summary>
     /// The <see cref="MdbColumnType" /> that can be used for this value.
@@ -36,5 +42,5 @@ internal sealed class MdbSingleValue : MdbValue<float>, IValueAllowableType
     /// <summary>
     /// The value for the specific row and column. A <see cref="float" />.
     /// </summary>
-    public override float Value => ConversionFunctions.AsSingle(BinaryValue.AsSpan());
+    public override float Value { get; }
 }

--- a/src/MdbReader/Values/MdbStringValue.cs
+++ b/src/MdbReader/Values/MdbStringValue.cs
@@ -32,13 +32,14 @@ namespace MMKiwi.MdbReader.Values;
 internal sealed class MdbStringValue : MdbValue<string>, IValueAllowableType
 {
     //Not saving the string to the BinaryValue buffer in order to not duplicate it
-    internal MdbStringValue(MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
-        : base(column, isNull, ImmutableArray<byte>.Empty, 0, column.Length, AllowableType)
+    internal MdbStringValue(MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
+        : base(column, isNull, default, 0, column.Length, AllowableType)
     {
 
         Encoding = (column.ColumnInfo as MdbTextColumnInfo)!.Encoding;
 
-        Value = ConversionFunctions.AsString(Encoding, binaryValue.AsSpan());
+        Value = ConversionFunctions.AsString(Encoding, binaryValue);
+        RawValue = binaryValue.ToImmutableArray();
     }
 
     /// <summary>
@@ -80,5 +81,5 @@ internal sealed class MdbStringValue : MdbValue<string>, IValueAllowableType
     /// (for instance to write to disc), use <see cref="RawValue" /> instead.
     /// </para>
     /// </remarks>
-    public ImmutableArray<byte> RawValue => BinaryValue;
+    public ImmutableArray<byte> RawValue { get; }
 }

--- a/src/MdbReader/Values/MdbValue.cs
+++ b/src/MdbReader/Values/MdbValue.cs
@@ -163,7 +163,7 @@ internal abstract class MdbValue<TVal> : IMdbValue<TVal>
     /// <item><description>isNull is true but allowNull is false</description></item>
     /// </list>
     /// </exception>
-    private protected MdbValue(MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue, int minLength, int maxLength, MdbColumnType allowableType)
+    private protected MdbValue(MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue, int minLength, int maxLength, MdbColumnType allowableType)
     {
         if (column is null)
             throw new ArgumentNullException(nameof(column));
@@ -175,7 +175,6 @@ internal abstract class MdbValue<TVal> : IMdbValue<TVal>
 
         Column = column;
         IsNull = isNull;
-        BinaryValue = isNull ? ImmutableArray<byte>.Empty : binaryValue;
     }
 
     /// <summary>
@@ -188,8 +187,6 @@ internal abstract class MdbValue<TVal> : IMdbValue<TVal>
     /// </summary>
     [MemberNotNullWhen(false, nameof(Value))]
     public bool IsNull { get; }
-
-    private protected ImmutableArray<byte> BinaryValue { get; }
 
     /// <summary>
     /// The value for the specific row and column, converted from the raw 

--- a/src/MdbReader/Values/MdbValueFactory.cs
+++ b/src/MdbReader/Values/MdbValueFactory.cs
@@ -20,7 +20,7 @@ internal static class MdbValueFactory
     /// <param name="isNull"></param>
     /// <param name="binaryValue"></param>
     /// <returns></returns>
-    public static IMdbValue CreateValue(Jet3Reader reader, MdbColumn column, bool isNull, ImmutableArray<byte> binaryValue)
+    public static IMdbValue CreateValue(Jet3Reader reader, MdbColumn column, bool isNull, ReadOnlySpan<byte> binaryValue)
     {
         return (column.Type) switch
         {


### PR DESCRIPTION
I've noticed that that are a lot of object allocations during the mdb file parsing.
In this PR I modified the followings:
- For each cell an ImmutableArrray<byte> was created which allocates a byte[]. I've changed how the value type values are stored. Now they are stored directly in the MdbXxxValues classes

- There was a new SortedInt32KeyNode allocation for each node. A dictionary was created when the column count was greater than 10. I added an option to set this threshold. (In my applpication I acccess the fields by integer index, no I don't need any lookup dictionary for the fields)

- there was an unnecessary int[] allocation for the variable length columns... it can be stack allocated. (See  Jet3Reader.cs)

Before the changes:
<img width="803" height="825" alt="image" src="https://github.com/user-attachments/assets/bb6dbbd9-e28d-495d-bc27-130bcf62115b" />

After the changes:
<img width="806" height="699" alt="image" src="https://github.com/user-attachments/assets/cbc7d58e-ada6-49bb-952a-e864ea1b2556" />

So the total object allocation in my "test" apllication was reduced from 27 million to 12 million objects.