### PR TITLE
Fix Jet4 Memo truncation caused by stateless Jet4CompressedString decoder

### DIFF
--- a/src/MdbReader/MdbDataRow.String.cs
+++ b/src/MdbReader/MdbDataRow.String.cs
@@ -14,7 +14,7 @@ public sealed partial class MdbDataRow
     private string GetString(IMdbValue fieldValue) => fieldValue switch
     {
         MdbStringValue stringValue => stringValue.Value,
-        MdbMemoValue memoValue => memoValue.StreamReader!.ReadToEnd(),
+        MdbMemoValue memoValue => memoValue.Encoding.GetString(memoValue.Value!.ReadToEnd()),
         _ => ThrowInvalidCast<string>(fieldValue, nameof(String))
     };
 


### PR DESCRIPTION
GetString() used StreamReader.ReadToEnd() which decodes bytes in ~1024-byte chunks. The 0xFF 0xFE compression marker only appears once at the start of the full memo content, so only the first chunk decoded correctly as compressed ANSI. Subsequent chunks (each additional LVAL page) had no marker, causing the fallback Unicode.GetChars() path to produce half-length garbled output.

Fix reads all bytes at once via MdbLValStream.ReadToEnd() and decodes them in a single Encoding.GetString() call, ensuring the BOM is always present at the start of the full byte sequence.

Affects any Jet4 database with Memo fields spanning more than one LVAL page (~1024+ bytes). GetStreamReader() has the same underlying issue